### PR TITLE
two fixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,12 +25,18 @@ class Grc extends Base {
     this.init()
   }
 
+  onRequestSec (rid, service, payload, handler, cert) {
+    if (this.api) {
+      payload._isSecure = true
+      payload._cert = cert
+    }
+
+    this.onRequest(rid, service, payload, handler, cert)
+  }
+
   onRequest (rid, service, payload, handler, cert) {
     if (this.api) {
       const api = this.api
-
-      payload._isSecure = true
-      payload._cert = cert
 
       api.handle(service, payload, (err, res) => {
         handler.reply(_.isString(err) ? new Error(err) : err, res)
@@ -168,7 +174,7 @@ class Grc extends Base {
     if (!this.serviceSec && this.peerSec) {
       this.serviceSec = this.peerSecSrv.transport('server')
       this.serviceSec.listen(port + this.opts.secPortOffset)
-      this.serviceSec.on('request', this.onRequest.bind(this))
+      this.serviceSec.on('request', this.onRequestSec.bind(this))
     }
 
     async.auto({

--- a/index.js
+++ b/index.js
@@ -47,9 +47,6 @@ class Grc extends Base {
   }
 
   setupPeers () {
-    const ctx = this.ctx
-    const cal = this.cal
-
     if (!this.conf.protos) {
       this.conf.protos = ['gen', 'sec']
     }
@@ -102,8 +99,6 @@ class Grc extends Base {
   }
 
   _start (cb) {
-    const ctx = this.ctx
-
     async.series([
       next => { super._start(next) },
       next => {
@@ -203,7 +198,7 @@ class Grc extends Base {
           this.service.removeListener('request', this.onRequest.bind(this))
         }
 
-       if (this.serviceSec) {
+        if (this.serviceSec) {
           this.serviceSec.stop()
           this.serviceSec.removeListener('request', this.onRequest.bind(this))
         }

--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ class Grc extends Base {
         let acl = null
         try {
           const data = fs.readFileSync(`${secPath}/acl.json`)
-          acl = JSON.parse(acl)
+          acl = JSON.parse(data)
         } catch (err) {}
 
         this.aclSec = acl


### PR DESCRIPTION
```
sec: fix non-sec message handling 

the `_isSecure` property was set for each message, even for `gen`
protocols. this fix will just set the additional props for the
new secure grenache peers.
```

```
acl: fix acl parsing
```