### PR TITLE
announce: avoid too early announce

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,14 @@ class Grc extends Base {
       this.opts.secPortOffset = 2000
     }
 
+    caller.on('started', () => {
+      this._tickItv = setInterval(() => {
+        this.tick()
+      }, this.opts.tickInterval)
+
+      this.tick()
+    })
+
     this.init()
   }
 
@@ -142,12 +150,6 @@ class Grc extends Base {
           this.peerSec.init()
           this.peerSecSrv.init()
         }
-
-        this._tickItv = setInterval(() => {
-          this.tick()
-        }, this.opts.tickInterval)
-
-        this.tick()
 
         next()
       }


### PR DESCRIPTION
when there were async tasks to do, but facs were already loaded,
grenache workers would appear on the network and crash on request
because required dependent setup steps were not completed.

this pr lets the grc fac wait for a `started` event, which is
emitted after all start hooks have run.